### PR TITLE
fix: request.js tries to write body if webhook.form provided.

### DIFF
--- a/src/managers/WebhookManager.js
+++ b/src/managers/WebhookManager.js
@@ -167,10 +167,9 @@ class WebhookManager {
           }
         };
 
-
         const requestOptions = {
           auth: webhook.auth,
-          body: requestJSON || event.data,
+          body: requestFormData ? null : requestJSON || event.data,
           formData: requestFormData,
           headers: webhook.headers,
           json: !!requestJSON,

--- a/src/types.js
+++ b/src/types.js
@@ -4,7 +4,7 @@ import type { File } from 'express';
 import type DeviceFirmwareRepository from './repository/DeviceFirmwareFileRepository';
 
 export type Webhook = {
-  auth?: { Authorization: string },
+  auth?: { password: string, username: string },
   created_at: Date,
   deviceID?: string,
   errorResponseTopic?: string,
@@ -15,6 +15,7 @@ export type Webhook = {
   json?: { [key: string]: Object },
   mydevices?: boolean,
   noDefaults?: boolean,
+  ownerID: string,
   productIdOrSlug?: string,
   query?: { [key: string]: Object },
   rejectUnauthorized?: boolean,


### PR DESCRIPTION
Closes https://github.com/Brewskey/spark-server/issues/76
Well, I thought that request.js is a little bit more intelligent and it doesn't try to write request's body if we provide formData alongside.