### PR TITLE
remove supertest-as-promised

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "rimraf": "^2.5.4",
     "sinon": "^1.17.7",
     "supertest": "^2.0.1",
-    "supertest-as-promised": "^4.0.2",
     "uglifyjs": "^2.4.10"
   }
 }

--- a/test/DevicesController.test.js
+++ b/test/DevicesController.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable */
 import test from 'ava';
-import request from 'supertest-as-promised';
+import request from 'supertest';
 import ouathClients from '../src/oauthClients.json';
 import app from './setup/testApp';
 import TestData from './setup/TestData';

--- a/test/ProvisioningController.test.js
+++ b/test/ProvisioningController.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable */
 import test from 'ava';
-import request from 'supertest-as-promised';
+import request from 'supertest';
 import ouathClients from '../src/oauthClients.json';
 import app from './setup/testApp';
 import TestData from './setup/TestData';

--- a/test/UsersController.test.js
+++ b/test/UsersController.test.js
@@ -2,7 +2,7 @@
 import type {  TokenObject, UserCredentials } from '../src/types';
 
 import test from 'ava';
-import request from 'supertest-as-promised';
+import request from 'supertest';
 import ouathClients from '../src/oauthClients.json';
 import app from './setup/testApp';
 import TestData from './setup/TestData';

--- a/test/WebhooksController.test.js
+++ b/test/WebhooksController.test.js
@@ -2,7 +2,7 @@
 import type { Webhook, WebhookMutator } from '../src/types';
 
 import test from 'ava';
-import request from 'supertest-as-promised';
+import request from 'supertest';
 import ouathClients from '../src/oauthClients.json';
 import app from './setup/testApp';
 import settings from './setup/settings';


### PR DESCRIPTION
since 2.0 supertest support promises itself, so no needs for supertest-as-promised.