### PR TITLE
Added --no-cache to AVA in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "start": "nodemon --exec babel-node ./src/main.js --watch src --watch ../spark-protocol/dist --ignore data",
     "start:debug": "nodemon --exec babel-node ./src/main.js --watch src --watch ../spark-protocol/src --ignore data",
     "start:prod": "node ./dist/main.js",
-    "test": "ava --serial",
+    "test": "ava --serial --no-cache",
     "test:watch": "ava --watch --serial",
     "update-firmware": "node ./node_modules/spark-protocol/dist/scripts/update-firmware-binaries",
     "watch": "babel ./src --out-dir ./dist --watch"


### PR DESCRIPTION
This change will ensure npm test works without sudo on MacOS (or even other systems)

issue #210 

Please check if this works (is ok for you). 

Otherwise the node_modules folder needs to be writeable for all users 